### PR TITLE
Fix Die Hard damage multiplier

### DIFF
--- a/lua/upgradestweakdata.lua
+++ b/lua/upgradestweakdata.lua
@@ -382,7 +382,7 @@ function UpgradesTweakData:init(tweak_data)
 	self.skill_descs.defense_up.multipro = "50%"
 
 	-- Die Hard
-	self.values.player.interacting_damage_multiplier[1] = 0.25
+	self.values.player.interacting_damage_multiplier[1] = 0.75
 	self.skill_descs.sentry_targeting_package.multibasic = "25%"
 
 	-- Defense Package


### PR DESCRIPTION
Fix Die Hard giving 75% damage reduction instead of intended 25%. This happens because the value is a multiplier and 0.25 gives 75% damage reduction.