### PR TITLE
Fix VR specific crash when firing weapons

### DIFF
--- a/lua/playerstandardvr.lua
+++ b/lua/playerstandardvr.lua
@@ -167,7 +167,7 @@ function PlayerStandardVR:_check_fire_per_weapon(t, pressed, held, released, wea
 			local recoil_multiplier = (weap_base:recoil() + weap_base:recoil_addend()) * weap_base:recoil_multiplier()
 			local weap_tweak_data = tweak_data.weapon[weap_base:get_name_id()]
 			local shake_tweak_data = weap_tweak_data.shake[fire_mode] or weap_tweak_data.shake
-			local recoil_shake = linear_lerp(recoil_multiplier, 0.5, 3, 0.8, 1.2)
+			local recoil_shake = math.map_range(recoil_multiplier, 0.5, 3, 0.8, 1.2)
 			local shake_multiplier = shake_tweak_data["fire_multiplier"] * recoil_shake
 
 			if self._state_data.in_steelsight then


### PR DESCRIPTION
mods/Eclipse-Difficulty-dev/lua/playerstandardvr.lua:170: attempt to call global 'linear_lerp' (a nil value)



SCRIPT STACK

_check_action_primary_attack() lib/units/beings/player/states/vr/playerstandardvr.lua:1319
_update_check_actions() lib/units/beings/player/states/playerstandard.lua:1091
original() @mods/Eclipse-Difficulty-dev/lua/playerstandard.lua:550
__update_standard() @mods/base/req/core/Hooks.lua:266
update() lib/units/beings/player/states/vr/playerstandardvr.lua:710
@mods/BeardLib/Hooks/Maps/Hooks.lua:231

fixes this I guess, probably the most dogshit low effort pull request lmao