### PR TITLE
Disable pre-order discount upgrade

### DIFF
--- a/lua/dlctweakdata.lua
+++ b/lua/dlctweakdata.lua
@@ -10,4 +10,30 @@ Hooks:PostHook(DLCTweakData, "init", "eclipse_init", function(self)
 			item_entry = "wpn_fps_upg_charm_eclipse",
 		},
 	}
+	
+	self.preorder.content.loot_drops = {
+		{
+			type_items = "colors",
+			item_entry = "red_black",
+			amount = 1
+		},
+		{
+			type_items = "textures",
+			item_entry = "fan",
+			amount = 1
+		},
+		{
+			type_items = "masks",
+			item_entry = "skull",
+			amount = 1
+		},
+		{
+			type_items = "weapon_mods",
+			item_entry = "wpn_fps_upg_o_aimpoint_2",
+			amount = 1
+		}
+	}
+
+	table.delete(self.preorder.content.upgrades, "player_crime_net_deal")
+	table.delete(self.cce.content.upgrades, "player_crime_net_deal_2")
 end)


### PR DESCRIPTION
DLC Unlocker users (or people that actually preordered the CCE version of the game) receive a 20% discount on practically anything that involves using your spending cash. Disabling it should allow an even ground for everyone as well as easier time balancing anything that involves prices n' stuff.

Comparison image below:
<img width="857" height="106" alt="preorder" src="https://github.com/user-attachments/assets/a9df49ee-f9e4-41f1-a8df-0c3cf18756a2" />
