### PR TITLE
Shotgun FX for each ammo type

### DIFF
--- a/assets/effects/particles/weapons/sho_buckshot.effect
+++ b/assets/effects/particles/weapons/sho_buckshot.effect
@@ -1,0 +1,148 @@
+<effect force_synch="false">
+    <atom name="flame base" min_size="1" max_size="4" lifetime="0.4" random_start_time="false" start_time="0" preroll="0" inherit_velocity_multiplier="1" fade_in_start="-1" fade_in_length="0" fade_out_start="-1" spawn_cull_policy="kill" cull_policy="kill" cull_gracetime="0" max_particle_radius="-1" soundbank="" cue="" ambient="false" grab_relative="effect" grab_pos="0 0 0" grab_radius="200" grab_backfacing="false" timeline="">
+        <initializerstack>
+            <boxrandomrotation relative="effect" min="0 1 0" max="0 1 0" min_rot="0" max_rot="0"/>
+            <localboxrandomposition min="0 0 0" max="0 0 0"/>
+            <boxrandomaspectsize size="10 10" min="0.5" max="1"/>
+            <boxrandomuvoffset uv_size="0.25 0.5" frame_start="0 0" primary_step_direction="+x" secondary_step_direction="+y" num_frames="3"/>
+            <boxrandomangle min="0" max="360"/>
+            <boxrandomvelocity relative="effect" min="0 500 0" max="0 1500 0"/>
+        </initializerstack>
+        <simulatorstack>
+            <worldtransform transform_rotations="false"/>
+            <velocityintegrator channel="world"/>
+        </simulatorstack>
+        <visualizerstack>
+            <billboard texture="effects/textures/add_atlas_df" intensity="identity" billboard_type="camera_facing" rotation_channel="world_rotation" blend_mode="add" render_template="effect_op_halo" origo="0.5 0.5" per_particle_age="false" size_input="scaled_channel" color_input="constant" color="104.00000762939 88 66" opacity_input="keys" rotation_input="channel" rotation_axis="0 0 1" uv_size="0.25 0.0625" uv_offset_input="channel">
+                <size_scale_keys loop="false">
+                    <key t="0" v="1 1"/>
+                    <key t="0.06540447473526" v="2 2"/>
+                </size_scale_keys>
+                <opacity_keys loop="false">
+                    <key t="0.020654045045376" v="255"/>
+                    <key t="0.079" v="0"/>
+                </opacity_keys>
+            </billboard>
+        </visualizerstack>
+    </atom>
+    <atom name="sparks forward" min_size="6" max_size="6" lifetime="1" random_start_time="false" start_time="0" preroll="0" inherit_velocity_multiplier="1" fade_in_start="-1" fade_in_length="0" fade_out_start="-1" spawn_cull_policy="initialize" cull_policy="kill" cull_gracetime="1" max_particle_radius="-1" soundbank="" cue="" ambient="false" grab_relative="effect" grab_pos="0 0 0" grab_radius="200" grab_backfacing="false" timeline="">
+        <initializerstack>
+            <boxrandomvelocity relative="effect" min="-110 900 -110" max="110 2600 110"/>
+            <boxrandomaspectsize size="1 1" min="1" max="4"/>
+            <boxrandomrotation relative="effect" min="0 0 0" max="0 0 0" min_rot="0" max_rot="0"/>
+            <boxrandomposition relative="effect" min="-1 -1 -1" max="1 1 1"/>
+        </initializerstack>
+        <simulatorstack>
+            <velocityintegrator channel="world"/>
+            <rotationbyvelocity velocity="500"/>
+            <constantacceleration relative="world" acceleration="0 0 -200"/>
+        </simulatorstack>
+        <visualizerstack>
+            <billboard texture="effects/textures/add_atlas_df" intensity="identity" billboard_type="rotation_aligned" rotation_channel="world_rotation" blend_mode="normal" render_template="effect_op_add" origo="0.5 0" per_particle_age="false" size_input="scaled_channel" color_input="constant" color="255 124.00000762939 66" opacity_input="keys" rotation_input="constant" rotation="0" rotation_axis="0 0 1" uv_size="0.25 0.0625" uv_offset_input="constant" uv_offset="0 0.0625">
+                <size_scale_keys loop="false">
+                    <key t="0" v="6 6"/>
+                    <key t="0.092943198978901" v="4 4"/>
+                    <key t="0.60585200786591" v="0 0"/>
+                </size_scale_keys>
+                <opacity_keys loop="false">
+                    <key t="0" v="255"/>
+                    <key t="0.2" v="185"/>
+                    <key t="0.56110155582428" v="75"/>
+                    <key t="0.76075732707977" v="0"/>
+                </opacity_keys>
+            </billboard>
+        </visualizerstack>
+    </atom>
+    <atom name="outer flame" min_size="1" max_size="1" lifetime="0.12" random_start_time="false" start_time="0" preroll="0" inherit_velocity_multiplier="1" fade_in_start="-1" fade_in_length="0" fade_out_start="-1" spawn_cull_policy="kill" cull_policy="kill" cull_gracetime="0" max_particle_radius="-1" soundbank="" cue="" ambient="false" grab_relative="effect" grab_pos="0 0 0" grab_radius="200" grab_backfacing="false" timeline="">
+        <initializerstack>
+            <boxrandomvelocity relative="effect" min="0 100 0" max="0 100 0"/>
+            <boxrandomaspectsize size="15 15" min="0.7" max="1.5"/>
+            <boxrandomuvoffset uv_size="0.25 0.5" frame_start="0 0.0625" primary_step_direction="+x" secondary_step_direction="+y" num_frames="3"/>
+            <localboxrandomposition min="0 0 0" max="0 0 0"/>
+            <boxrandomopacity min="150" max="255"/>
+        </initializerstack>
+        <simulatorstack>
+            <worldtransform transform_rotations="false"/>
+        </simulatorstack>
+        <visualizerstack>
+            <billboard texture="effects/textures/add_atlas_df" intensity="sun" billboard_type="camera_facing" rotation_channel="rotation" blend_mode="add" render_template="effect_op_halo" origo="0.5 0.5" per_particle_age="false" size_input="scaled_channel" color_input="constant" color="247.00001525879 95 0" opacity_input="keys" rotation_input="constant" rotation="0" rotation_axis="0 0 0" uv_size="0.25 0.0625" uv_offset_input="channel">
+                <size_scale_keys loop="false">
+                    <key t="0" v="1 1"/>
+                    <key t="0.068846814334393" v="2 2"/>
+                </size_scale_keys>
+                <opacity_keys loop="false">
+                    <key t="0" v="255"/>
+                    <key t="0.082616180181503" v="0"/>
+                </opacity_keys>
+            </billboard>
+        </visualizerstack>
+    </atom>
+    <atom name="smoke base" min_size="5" max_size="5" lifetime=".5" random_start_time="false" start_time="0" preroll="0" inherit_velocity_multiplier="1" fade_in_start="-1" fade_in_length="0" fade_out_start="-1" spawn_cull_policy="kill" cull_policy="kill" cull_gracetime="0" max_particle_radius="-1" soundbank="" cue="" ambient="false" grab_relative="effect" grab_pos="0 0 0" grab_radius="200" grab_backfacing="false" timeline="">
+        <initializerstack>
+            <boxrandomvelocity relative="effect" min="-150 400 -150" max="150 500 150"/>
+            <boxrandomrotation relative="effect" min="1 1 0" max="1 1 1" min_rot="0365" max_rot="0"/>
+            <boxrandomaspectsize size="40 40" min="1" max="1.2"/>
+            <boxrandomposition relative="effect" min="0 25 0" max="0 32 0"/>
+            <boxrandomuvoffset uv_size="0.25 0.5" frame_start="0 0.0625" primary_step_direction="+x" secondary_step_direction="+y" num_frames="3"/>
+            <boxrandomangle min="0" max="360"/>
+            <boxrandomanglevelocity min="4" max="-4"/>
+        </initializerstack>
+        <simulatorstack>
+            <velocityintegrator channel="world"/>
+            <anglevelocityintegrator/>
+        </simulatorstack>
+        <visualizerstack>
+            <billboard texture="effects/textures/opacity_atlas_df" intensity="identity" billboard_type="camera_facing" rotation_channel="world_rotation" blend_mode="normal" render_template="effect_op" origo="0.5 0.5" per_particle_age="false" size_input="scaled_channel" color_input="constant" color="83 83 83" opacity_input="keys" rotation_input="channel" rotation_axis="1 1 1" uv_size="0.5 0.25" uv_offset_input="constant" uv_offset="0 0.5625">
+                <size_scale_keys loop="false">
+                    <key t="0" v="1 1"/>
+                    <key t="0.41308090090752" v="3 3"/>
+                </size_scale_keys>
+                <opacity_keys loop="false">
+                    <key t="0" v="50"/>
+                    <key t="0.26506024599075" v="40"/>
+                    <key t="0.44406196475029" v="0"/>
+                </opacity_keys>
+            </billboard>
+        </visualizerstack>
+    </atom>
+    <atom name="smoke base0" min_size="4" max_size="4" lifetime="0.4" random_start_time="false" start_time="0" preroll="0" inherit_velocity_multiplier="1" fade_in_start="-1" fade_in_length="0" fade_out_start="-1" spawn_cull_policy="kill" cull_policy="kill" cull_gracetime="0" max_particle_radius="-1" soundbank="" cue="" ambient="false" grab_relative="effect" grab_pos="0 0 0" grab_radius="200" grab_backfacing="false" timeline="">
+        <initializerstack>
+            <boxrandomvelocity relative="effect" min="0 500 25" max="0 600 25"/>
+            <boxrandomrotation relative="effect" min="1 1 0" max="1 1 1" min_rot="0365" max_rot="0"/>
+            <boxrandomaspectsize size="40 40" min="1" max="1.2"/>
+            <boxrandomposition relative="effect" min="0 25 0" max="0 32 0"/>
+            <boxrandomuvoffset uv_size="0.25 0.5" frame_start="0 0.0625" primary_step_direction="+x" secondary_step_direction="+y" num_frames="3"/>
+        </initializerstack>
+        <simulatorstack>
+            <velocityintegrator channel="world"/>
+        </simulatorstack>
+        <visualizerstack>
+            <billboard texture="effects/textures/opacity_atlas_df" intensity="candle" billboard_type="camera_facing" rotation_channel="world_rotation" blend_mode="normal" render_template="effect_op" origo="0.5 0.5" per_particle_age="false" size_input="scaled_channel" color_input="constant" color="40 40 40" opacity_input="keys" rotation_input="keys" rotation_axis="1 1 1" uv_size="0.5 0.25" uv_offset_input="constant" uv_offset="0 0.5625">
+                <size_scale_keys loop="false">
+                    <key t="0" v="0.80000001192093 0.80000001192093"/>
+                    <key t="0.39931198954582" v="2 2"/>
+                </size_scale_keys>
+                <opacity_keys loop="false">
+                    <key t="0" v="0"/>
+                    <key t="0.074450083076954" v="80"/>
+                    <key t="0.26734349131584" v="0"/>
+                </opacity_keys>
+                <rotation_keys loop="false">
+                    <key t="0" v="2"/>
+                    <key t="1.209876537323" v="0"/>
+                </rotation_keys>
+            </billboard>
+        </visualizerstack>
+    </atom>
+    <atom name="light" min_size="1" max_size="1" lifetime="0.1" random_start_time="false" start_time="0" preroll="0" inherit_velocity_multiplier="1" fade_in_start="-1" fade_in_length="0" fade_out_start="-1" spawn_cull_policy="kill" cull_policy="kill" cull_gracetime="0" max_particle_radius="-1" soundbank="" cue="" ambient="false" grab_relative="effect" grab_pos="0 0 0" grab_radius="200" grab_backfacing="false" timeline="">
+        <initializerstack>
+            <localboxrandomposition min="0 160 0" max="0 166 0"/>
+        </initializerstack>
+        <simulatorstack>
+            <worldtransform transform_rotations="false"/>
+        </simulatorstack>
+        <visualizerstack>
+            <light per_particle_age="false" shadow_caster="false" specular="true" color_input="constant" color="224.00001525879 209.00001525879 156" multiplier_input="constant" multiplier="0.002" far_range_input="constant" far_range="300"/>
+        </visualizerstack>
+    </atom>
+</effect>

--- a/assets/effects/particles/weapons/sho_default.effect
+++ b/assets/effects/particles/weapons/sho_default.effect
@@ -1,0 +1,148 @@
+<effect force_synch="false">
+    <atom name="flame base" min_size="1" max_size="4" lifetime="0.4" random_start_time="false" start_time="0" preroll="0" inherit_velocity_multiplier="1" fade_in_start="-1" fade_in_length="0" fade_out_start="-1" spawn_cull_policy="kill" cull_policy="kill" cull_gracetime="0" max_particle_radius="-1" soundbank="" cue="" ambient="false" grab_relative="effect" grab_pos="0 0 0" grab_radius="200" grab_backfacing="false" timeline="">
+        <initializerstack>
+            <boxrandomrotation relative="effect" min="0 1 0" max="0 1 0" min_rot="0" max_rot="0"/>
+            <localboxrandomposition min="0 0 0" max="0 0 0"/>
+            <boxrandomaspectsize size="10 10" min="0.5" max="1"/>
+            <boxrandomuvoffset uv_size="0.25 0.5" frame_start="0 0" primary_step_direction="+x" secondary_step_direction="+y" num_frames="3"/>
+            <boxrandomangle min="0" max="360"/>
+            <boxrandomvelocity relative="effect" min="0 500 0" max="0 1500 0"/>
+        </initializerstack>
+        <simulatorstack>
+            <worldtransform transform_rotations="false"/>
+            <velocityintegrator channel="world"/>
+        </simulatorstack>
+        <visualizerstack>
+            <billboard texture="effects/textures/add_atlas_df" intensity="identity" billboard_type="camera_facing" rotation_channel="world_rotation" blend_mode="add" render_template="effect_op_halo" origo="0.5 0.5" per_particle_age="false" size_input="scaled_channel" color_input="constant" color="104.00000762939 88 66" opacity_input="keys" rotation_input="channel" rotation_axis="0 0 1" uv_size="0.25 0.0625" uv_offset_input="channel">
+                <size_scale_keys loop="false">
+                    <key t="0" v="1 1"/>
+                    <key t="0.06540447473526" v="2 2"/>
+                </size_scale_keys>
+                <opacity_keys loop="false">
+                    <key t="0.020654045045376" v="255"/>
+                    <key t="0.079" v="0"/>
+                </opacity_keys>
+            </billboard>
+        </visualizerstack>
+    </atom>
+    <atom name="sparks forward" min_size="8" max_size="8" lifetime="1" random_start_time="false" start_time="0" preroll="0" inherit_velocity_multiplier="1" fade_in_start="-1" fade_in_length="0" fade_out_start="-1" spawn_cull_policy="initialize" cull_policy="kill" cull_gracetime="1" max_particle_radius="-1" soundbank="" cue="" ambient="false" grab_relative="effect" grab_pos="0 0 0" grab_radius="200" grab_backfacing="false" timeline="">
+        <initializerstack>
+            <boxrandomvelocity relative="effect" min="-110 900 -110" max="110 2600 110"/>
+            <boxrandomaspectsize size="1 1" min="1" max="4"/>
+            <boxrandomrotation relative="effect" min="0 0 0" max="0 0 0" min_rot="0" max_rot="0"/>
+            <boxrandomposition relative="effect" min="-1 -1 -1" max="1 1 1"/>
+        </initializerstack>
+        <simulatorstack>
+            <velocityintegrator channel="world"/>
+            <rotationbyvelocity velocity="500"/>
+            <constantacceleration relative="world" acceleration="0 0 -200"/>
+        </simulatorstack>
+        <visualizerstack>
+            <billboard texture="effects/textures/add_atlas_df" intensity="identity" billboard_type="rotation_aligned" rotation_channel="world_rotation" blend_mode="normal" render_template="effect_op_add" origo="0.5 0" per_particle_age="false" size_input="scaled_channel" color_input="constant" color="255 217.00001525879 173" opacity_input="keys" rotation_input="constant" rotation="0" rotation_axis="0 0 1" uv_size="0.25 0.0625" uv_offset_input="constant" uv_offset="0 0.0625">
+                <size_scale_keys loop="false">
+                    <key t="0" v="3 3"/>
+                    <key t="0.092943198978901" v="2 2"/>
+                    <key t="0.60585200786591" v="0 0"/>
+                </size_scale_keys>
+                <opacity_keys loop="false">
+                    <key t="0" v="255"/>
+                    <key t="0.2" v="185"/>
+                    <key t="0.56110155582428" v="75"/>
+                    <key t="0.76075732707977" v="0"/>
+                </opacity_keys>
+            </billboard>
+        </visualizerstack>
+    </atom>
+    <atom name="outer flame" min_size="1" max_size="1" lifetime="0.12" random_start_time="false" start_time="0" preroll="0" inherit_velocity_multiplier="1" fade_in_start="-1" fade_in_length="0" fade_out_start="-1" spawn_cull_policy="kill" cull_policy="kill" cull_gracetime="0" max_particle_radius="-1" soundbank="" cue="" ambient="false" grab_relative="effect" grab_pos="0 0 0" grab_radius="200" grab_backfacing="false" timeline="">
+        <initializerstack>
+            <boxrandomvelocity relative="effect" min="0 100 0" max="0 100 0"/>
+            <boxrandomaspectsize size="15 15" min="0.7" max="1.5"/>
+            <boxrandomuvoffset uv_size="0.25 0.5" frame_start="0 0.0625" primary_step_direction="+x" secondary_step_direction="+y" num_frames="3"/>
+            <localboxrandomposition min="0 0 0" max="0 0 0"/>
+            <boxrandomopacity min="150" max="255"/>
+        </initializerstack>
+        <simulatorstack>
+            <worldtransform transform_rotations="false"/>
+        </simulatorstack>
+        <visualizerstack>
+            <billboard texture="effects/textures/add_atlas_df" intensity="sun" billboard_type="camera_facing" rotation_channel="rotation" blend_mode="add" render_template="effect_op_halo" origo="0.5 0.5" per_particle_age="false" size_input="scaled_channel" color_input="constant" color="192.00001525879 190 188" opacity_input="keys" rotation_input="constant" rotation="0" rotation_axis="0 0 0" uv_size="0.25 0.0625" uv_offset_input="channel">
+                <size_scale_keys loop="false">
+                    <key t="0" v="1 1"/>
+                    <key t="0.068846814334393" v="2 2"/>
+                </size_scale_keys>
+                <opacity_keys loop="false">
+                    <key t="0" v="255"/>
+                    <key t="0.082616180181503" v="0"/>
+                </opacity_keys>
+            </billboard>
+        </visualizerstack>
+    </atom>
+    <atom name="smoke base" min_size="5" max_size="5" lifetime=".5" random_start_time="false" start_time="0" preroll="0" inherit_velocity_multiplier="1" fade_in_start="-1" fade_in_length="0" fade_out_start="-1" spawn_cull_policy="kill" cull_policy="kill" cull_gracetime="0" max_particle_radius="-1" soundbank="" cue="" ambient="false" grab_relative="effect" grab_pos="0 0 0" grab_radius="200" grab_backfacing="false" timeline="">
+        <initializerstack>
+            <boxrandomvelocity relative="effect" min="-150 400 -150" max="150 500 150"/>
+            <boxrandomrotation relative="effect" min="1 1 0" max="1 1 1" min_rot="0365" max_rot="0"/>
+            <boxrandomaspectsize size="40 40" min="1" max="1.2"/>
+            <boxrandomposition relative="effect" min="0 25 0" max="0 32 0"/>
+            <boxrandomuvoffset uv_size="0.25 0.5" frame_start="0 0.0625" primary_step_direction="+x" secondary_step_direction="+y" num_frames="3"/>
+            <boxrandomangle min="0" max="360"/>
+            <boxrandomanglevelocity min="4" max="-4"/>
+        </initializerstack>
+        <simulatorstack>
+            <velocityintegrator channel="world"/>
+            <anglevelocityintegrator/>
+        </simulatorstack>
+        <visualizerstack>
+            <billboard texture="effects/textures/opacity_atlas_df" intensity="identity" billboard_type="camera_facing" rotation_channel="world_rotation" blend_mode="normal" render_template="effect_op" origo="0.5 0.5" per_particle_age="false" size_input="scaled_channel" color_input="constant" color="83 83 83" opacity_input="keys" rotation_input="channel" rotation_axis="1 1 1" uv_size="0.5 0.25" uv_offset_input="constant" uv_offset="0 0.5625">
+                <size_scale_keys loop="false">
+                    <key t="0" v="1 1"/>
+                    <key t="0.41308090090752" v="3 3"/>
+                </size_scale_keys>
+                <opacity_keys loop="false">
+                    <key t="0" v="50"/>
+                    <key t="0.26506024599075" v="40"/>
+                    <key t="0.44406196475029" v="0"/>
+                </opacity_keys>
+            </billboard>
+        </visualizerstack>
+    </atom>
+    <atom name="smoke base0" min_size="4" max_size="4" lifetime="0.4" random_start_time="false" start_time="0" preroll="0" inherit_velocity_multiplier="1" fade_in_start="-1" fade_in_length="0" fade_out_start="-1" spawn_cull_policy="kill" cull_policy="kill" cull_gracetime="0" max_particle_radius="-1" soundbank="" cue="" ambient="false" grab_relative="effect" grab_pos="0 0 0" grab_radius="200" grab_backfacing="false" timeline="">
+        <initializerstack>
+            <boxrandomvelocity relative="effect" min="0 500 25" max="0 600 25"/>
+            <boxrandomrotation relative="effect" min="1 1 0" max="1 1 1" min_rot="0365" max_rot="0"/>
+            <boxrandomaspectsize size="40 40" min="1" max="1.2"/>
+            <boxrandomposition relative="effect" min="0 25 0" max="0 32 0"/>
+            <boxrandomuvoffset uv_size="0.25 0.5" frame_start="0 0.0625" primary_step_direction="+x" secondary_step_direction="+y" num_frames="3"/>
+        </initializerstack>
+        <simulatorstack>
+            <velocityintegrator channel="world"/>
+        </simulatorstack>
+        <visualizerstack>
+            <billboard texture="effects/textures/opacity_atlas_df" intensity="candle" billboard_type="camera_facing" rotation_channel="world_rotation" blend_mode="normal" render_template="effect_op" origo="0.5 0.5" per_particle_age="false" size_input="scaled_channel" color_input="constant" color="40 40 40" opacity_input="keys" rotation_input="keys" rotation_axis="1 1 1" uv_size="0.5 0.25" uv_offset_input="constant" uv_offset="0 0.5625">
+                <size_scale_keys loop="false">
+                    <key t="0" v="0.80000001192093 0.80000001192093"/>
+                    <key t="0.39931198954582" v="2 2"/>
+                </size_scale_keys>
+                <opacity_keys loop="false">
+                    <key t="0" v="0"/>
+                    <key t="0.074450083076954" v="80"/>
+                    <key t="0.26734349131584" v="0"/>
+                </opacity_keys>
+                <rotation_keys loop="false">
+                    <key t="0" v="2"/>
+                    <key t="1.209876537323" v="0"/>
+                </rotation_keys>
+            </billboard>
+        </visualizerstack>
+    </atom>
+    <atom name="light" min_size="1" max_size="1" lifetime="0.1" random_start_time="false" start_time="0" preroll="0" inherit_velocity_multiplier="1" fade_in_start="-1" fade_in_length="0" fade_out_start="-1" spawn_cull_policy="kill" cull_policy="kill" cull_gracetime="0" max_particle_radius="-1" soundbank="" cue="" ambient="false" grab_relative="effect" grab_pos="0 0 0" grab_radius="200" grab_backfacing="false" timeline="">
+        <initializerstack>
+            <localboxrandomposition min="0 160 0" max="0 166 0"/>
+        </initializerstack>
+        <simulatorstack>
+            <worldtransform transform_rotations="false"/>
+        </simulatorstack>
+        <visualizerstack>
+            <light per_particle_age="false" shadow_caster="false" specular="true" color_input="constant" color="224.00001525879 209.00001525879 156" multiplier_input="constant" multiplier="0.002" far_range_input="constant" far_range="300"/>
+        </visualizerstack>
+    </atom>
+</effect>

--- a/assets/effects/particles/weapons/sho_flechette.effect
+++ b/assets/effects/particles/weapons/sho_flechette.effect
@@ -1,0 +1,148 @@
+<effect force_synch="false">
+    <atom name="flame base" min_size="1" max_size="4" lifetime="0.4" random_start_time="false" start_time="0" preroll="0" inherit_velocity_multiplier="1" fade_in_start="-1" fade_in_length="0" fade_out_start="-1" spawn_cull_policy="kill" cull_policy="kill" cull_gracetime="0" max_particle_radius="-1" soundbank="" cue="" ambient="false" grab_relative="effect" grab_pos="0 0 0" grab_radius="200" grab_backfacing="false" timeline="">
+        <initializerstack>
+            <boxrandomrotation relative="effect" min="0 1 0" max="0 1 0" min_rot="0" max_rot="0"/>
+            <localboxrandomposition min="0 0 0" max="0 0 0"/>
+            <boxrandomaspectsize size="10 10" min="0.5" max="1"/>
+            <boxrandomuvoffset uv_size="0.25 0.5" frame_start="0 0" primary_step_direction="+x" secondary_step_direction="+y" num_frames="3"/>
+            <boxrandomangle min="0" max="360"/>
+            <boxrandomvelocity relative="effect" min="0 500 0" max="0 1500 0"/>
+        </initializerstack>
+        <simulatorstack>
+            <worldtransform transform_rotations="false"/>
+            <velocityintegrator channel="world"/>
+        </simulatorstack>
+        <visualizerstack>
+            <billboard texture="effects/textures/add_atlas_df" intensity="identity" billboard_type="camera_facing" rotation_channel="world_rotation" blend_mode="add" render_template="effect_op_halo" origo="0.5 0.5" per_particle_age="false" size_input="scaled_channel" color_input="constant" color="104.00000762939 88 66" opacity_input="keys" rotation_input="channel" rotation_axis="0 0 1" uv_size="0.25 0.0625" uv_offset_input="channel">
+                <size_scale_keys loop="false">
+                    <key t="0" v="1 1"/>
+                    <key t="0.06540447473526" v="2 2"/>
+                </size_scale_keys>
+                <opacity_keys loop="false">
+                    <key t="0.020654045045376" v="255"/>
+                    <key t="0.079" v="0"/>
+                </opacity_keys>
+            </billboard>
+        </visualizerstack>
+    </atom>
+    <atom name="sparks forward" min_size="12" max_size="12" lifetime="2" random_start_time="false" start_time="0" preroll="0" inherit_velocity_multiplier="1" fade_in_start="-1" fade_in_length="0" fade_out_start="-1" spawn_cull_policy="initialize" cull_policy="kill" cull_gracetime="1" max_particle_radius="-1" soundbank="" cue="" ambient="false" grab_relative="effect" grab_pos="0 0 0" grab_radius="200" grab_backfacing="false" timeline="">
+        <initializerstack>
+            <boxrandomvelocity relative="effect" min="-110 900 -110" max="110 2600 110"/>
+            <boxrandomaspectsize size="1 1" min="1" max="4"/>
+            <boxrandomrotation relative="effect" min="0 0 0" max="0 0 0" min_rot="0" max_rot="0"/>
+            <boxrandomposition relative="effect" min="-1 -1 -1" max="1 1 1"/>
+        </initializerstack>
+        <simulatorstack>
+            <velocityintegrator channel="world"/>
+            <rotationbyvelocity velocity="500"/>
+            <constantacceleration relative="world" acceleration="0 0 -200"/>
+        </simulatorstack>
+        <visualizerstack>
+            <billboard texture="effects/textures/add_atlas_df" intensity="neonsign" billboard_type="rotation_aligned" rotation_channel="world_rotation" blend_mode="normal" render_template="effect_op_add" origo="0.5 0" per_particle_age="false" size_input="scaled_channel" color_input="constant" color="75 255 255" opacity_input="keys" rotation_input="constant" rotation="0" rotation_axis="0 0 1" uv_size="0.25 0.0625" uv_offset_input="constant" uv_offset="0 0.0625">
+                <size_scale_keys loop="false">
+                    <key t="0" v="3 3"/>
+                    <key t="0.092943198978901" v="2 2"/>
+                    <key t="0.60585200786591" v="0 0"/>
+                </size_scale_keys>
+                <opacity_keys loop="false">
+                    <key t="0" v="255"/>
+                    <key t="0.2" v="200"/>
+                    <key t="0.56110155582428" v="145"/>
+                    <key t="0.76075732707977" v="0"/>
+                </opacity_keys>
+            </billboard>
+        </visualizerstack>
+    </atom>
+    <atom name="outer flame" min_size="1" max_size="1" lifetime="0.12" random_start_time="false" start_time="0" preroll="0" inherit_velocity_multiplier="1" fade_in_start="-1" fade_in_length="0" fade_out_start="-1" spawn_cull_policy="kill" cull_policy="kill" cull_gracetime="0" max_particle_radius="-1" soundbank="" cue="" ambient="false" grab_relative="effect" grab_pos="0 0 0" grab_radius="200" grab_backfacing="false" timeline="">
+        <initializerstack>
+            <boxrandomvelocity relative="effect" min="0 100 0" max="0 100 0"/>
+            <boxrandomaspectsize size="15 15" min="0.7" max="1.5"/>
+            <boxrandomuvoffset uv_size="0.25 0.5" frame_start="0 0.0625" primary_step_direction="+x" secondary_step_direction="+y" num_frames="3"/>
+            <localboxrandomposition min="0 0 0" max="0 0 0"/>
+            <boxrandomopacity min="150" max="255"/>
+        </initializerstack>
+        <simulatorstack>
+            <worldtransform transform_rotations="false"/>
+        </simulatorstack>
+        <visualizerstack>
+            <billboard texture="effects/textures/add_atlas_df" intensity="sun" billboard_type="camera_facing" rotation_channel="rotation" blend_mode="add" render_template="effect_op_halo" origo="0.5 0.5" per_particle_age="false" size_input="scaled_channel" color_input="constant" color="55.000003814697 97.000007629395 188" opacity_input="keys" rotation_input="constant" rotation="0" rotation_axis="0 0 0" uv_size="0.25 0.0625" uv_offset_input="channel">
+                <size_scale_keys loop="false">
+                    <key t="0" v="1 1"/>
+                    <key t="0.068846814334393" v="2 2"/>
+                </size_scale_keys>
+                <opacity_keys loop="false">
+                    <key t="0" v="255"/>
+                    <key t="0.082616180181503" v="0"/>
+                </opacity_keys>
+            </billboard>
+        </visualizerstack>
+    </atom>
+    <atom name="smoke base" min_size="5" max_size="5" lifetime=".5" random_start_time="false" start_time="0" preroll="0" inherit_velocity_multiplier="1" fade_in_start="-1" fade_in_length="0" fade_out_start="-1" spawn_cull_policy="kill" cull_policy="kill" cull_gracetime="0" max_particle_radius="-1" soundbank="" cue="" ambient="false" grab_relative="effect" grab_pos="0 0 0" grab_radius="200" grab_backfacing="false" timeline="">
+        <initializerstack>
+            <boxrandomvelocity relative="effect" min="-150 400 -150" max="150 500 150"/>
+            <boxrandomrotation relative="effect" min="1 1 0" max="1 1 1" min_rot="0365" max_rot="0"/>
+            <boxrandomaspectsize size="40 40" min="1" max="1.2"/>
+            <boxrandomposition relative="effect" min="0 25 0" max="0 32 0"/>
+            <boxrandomuvoffset uv_size="0.25 0.5" frame_start="0 0.0625" primary_step_direction="+x" secondary_step_direction="+y" num_frames="3"/>
+            <boxrandomangle min="0" max="360"/>
+            <boxrandomanglevelocity min="4" max="-4"/>
+        </initializerstack>
+        <simulatorstack>
+            <velocityintegrator channel="world"/>
+            <anglevelocityintegrator/>
+        </simulatorstack>
+        <visualizerstack>
+            <billboard texture="effects/textures/opacity_atlas_df" intensity="identity" billboard_type="camera_facing" rotation_channel="world_rotation" blend_mode="normal" render_template="effect_op" origo="0.5 0.5" per_particle_age="false" size_input="scaled_channel" color_input="constant" color="83 83 83" opacity_input="keys" rotation_input="channel" rotation_axis="1 1 1" uv_size="0.5 0.25" uv_offset_input="constant" uv_offset="0 0.5625">
+                <size_scale_keys loop="false">
+                    <key t="0" v="1 1"/>
+                    <key t="0.41308090090752" v="3 3"/>
+                </size_scale_keys>
+                <opacity_keys loop="false">
+                    <key t="0" v="50"/>
+                    <key t="0.26506024599075" v="40"/>
+                    <key t="0.44406196475029" v="0"/>
+                </opacity_keys>
+            </billboard>
+        </visualizerstack>
+    </atom>
+    <atom name="smoke base0" min_size="4" max_size="4" lifetime="0.4" random_start_time="false" start_time="0" preroll="0" inherit_velocity_multiplier="1" fade_in_start="-1" fade_in_length="0" fade_out_start="-1" spawn_cull_policy="kill" cull_policy="kill" cull_gracetime="0" max_particle_radius="-1" soundbank="" cue="" ambient="false" grab_relative="effect" grab_pos="0 0 0" grab_radius="200" grab_backfacing="false" timeline="">
+        <initializerstack>
+            <boxrandomvelocity relative="effect" min="0 500 25" max="0 600 25"/>
+            <boxrandomrotation relative="effect" min="1 1 0" max="1 1 1" min_rot="0365" max_rot="0"/>
+            <boxrandomaspectsize size="40 40" min="1" max="1.2"/>
+            <boxrandomposition relative="effect" min="0 25 0" max="0 32 0"/>
+            <boxrandomuvoffset uv_size="0.25 0.5" frame_start="0 0.0625" primary_step_direction="+x" secondary_step_direction="+y" num_frames="3"/>
+        </initializerstack>
+        <simulatorstack>
+            <velocityintegrator channel="world"/>
+        </simulatorstack>
+        <visualizerstack>
+            <billboard texture="effects/textures/opacity_atlas_df" intensity="candle" billboard_type="camera_facing" rotation_channel="world_rotation" blend_mode="normal" render_template="effect_op" origo="0.5 0.5" per_particle_age="false" size_input="scaled_channel" color_input="constant" color="40 40 40" opacity_input="keys" rotation_input="keys" rotation_axis="1 1 1" uv_size="0.5 0.25" uv_offset_input="constant" uv_offset="0 0.5625">
+                <size_scale_keys loop="false">
+                    <key t="0" v="0.80000001192093 0.80000001192093"/>
+                    <key t="0.39931198954582" v="2 2"/>
+                </size_scale_keys>
+                <opacity_keys loop="false">
+                    <key t="0" v="0"/>
+                    <key t="0.074450083076954" v="80"/>
+                    <key t="0.26734349131584" v="0"/>
+                </opacity_keys>
+                <rotation_keys loop="false">
+                    <key t="0" v="2"/>
+                    <key t="1.209876537323" v="0"/>
+                </rotation_keys>
+            </billboard>
+        </visualizerstack>
+    </atom>
+    <atom name="light" min_size="1" max_size="1" lifetime="0.1" random_start_time="false" start_time="0" preroll="0" inherit_velocity_multiplier="1" fade_in_start="-1" fade_in_length="0" fade_out_start="-1" spawn_cull_policy="kill" cull_policy="kill" cull_gracetime="0" max_particle_radius="-1" soundbank="" cue="" ambient="false" grab_relative="effect" grab_pos="0 0 0" grab_radius="200" grab_backfacing="false" timeline="">
+        <initializerstack>
+            <localboxrandomposition min="0 160 0" max="0 166 0"/>
+        </initializerstack>
+        <simulatorstack>
+            <worldtransform transform_rotations="false"/>
+        </simulatorstack>
+        <visualizerstack>
+            <light per_particle_age="false" shadow_caster="false" specular="true" color_input="constant" color="224.00001525879 209.00001525879 156" multiplier_input="constant" multiplier="0.002" far_range_input="constant" far_range="300"/>
+        </visualizerstack>
+    </atom>
+</effect>

--- a/assets/effects/particles/weapons/sho_tomb.effect
+++ b/assets/effects/particles/weapons/sho_tomb.effect
@@ -1,0 +1,161 @@
+<effect force_synch="false">
+    <atom name="locked_flash" min_size="1" max_size="1" lifetime="0.06" random_start_time="false" start_time="0" preroll="0" inherit_velocity_multiplier="1" fade_in_start="-1" fade_in_length="0" fade_out_start="-1" spawn_cull_policy="kill" cull_policy="kill" cull_gracetime="0" max_particle_radius="-1" soundbank="regular_weapon_sfx" cue="" ambient="false" grab_relative="effect" grab_pos="0 0 0" grab_radius="200" grab_backfacing="false" timeline="">
+        <initializerstack>
+            <localboxrandomposition min="0 15 0" max="0 25 0"/>
+            <boxrandomvelocity relative="effect" min="0 0 0" max="0 0 0"/>
+            <boxrandomangle min="0" max="360"/>
+            <boxrandomrotation relative="effect" min="0 0 0" max="0 0 0" min_rot="0" max_rot="0"/>
+            <boxrandomuvoffset uv_size="0.125 0.125" frame_start="0.5 0.375" primary_step_direction="+x" secondary_step_direction="+y" num_frames="4"/>
+            <boxrandomaspectsize size="32 32" min="2" max="3"/>
+        </initializerstack>
+        <simulatorstack>
+            <worldtransform transform_rotations="false"/>
+            <velocityintegrator channel="world"/>
+        </simulatorstack>
+        <visualizerstack>
+            <billboard texture="effects/textures/effects_atlas" intensity="identity" billboard_type="camera_facing" rotation_channel="world_rotation" blend_mode="add" render_template="effect_op_glow" origo="0.5 0.5" per_particle_age="false" size_input="channel" color_input="keys" opacity_input="constant" opacity="150" rotation_input="channel" rotation_axis="0 0 0" uv_size="0.125 0.125" uv_offset_input="channel">
+                <color_keys loop="false">
+                    <key t="0.0093457940965891" v="204 198 83"/>
+                    <key t="0.14018692076206" v="0 179 0"/>
+                    <key t="2" v="0 0 0"/>
+                </color_keys>
+            </billboard>
+        </visualizerstack>
+    </atom>
+    <atom name="shimmer" min_size="1" max_size="1" lifetime="0.4" random_start_time="false" start_time="0" preroll="0" inherit_velocity_multiplier="0" fade_in_start="-1" fade_in_length="0" fade_out_start="20" spawn_cull_policy="initialize" cull_policy="freeze" cull_gracetime="0" max_particle_radius="-1" soundbank="" cue="" ambient="false" grab_relative="effect" grab_pos="0 0 0" grab_radius="200" grab_backfacing="false" timeline="">
+        <initializerstack>
+            <localboxrandomposition min="0 0 0" max="0 0 0"/>
+            <boxrandomaspectsize size="6 6" min="2" max="3"/>
+            <boxrandomangle min="75" max="-90"/>
+        </initializerstack>
+        <simulatorstack>
+            <worldtransform transform_rotations="false"/>
+        </simulatorstack>
+        <visualizerstack>
+            <billboard texture="effects/textures/bullet_hit/e_dist_heat" intensity="" billboard_type="camera_facing" rotation_channel="rotation" blend_mode="normal" render_template="heat_shimmer" origo="0.5 0.5" per_particle_age="false" size_input="scaled_channel" color_input="constant" color="255 255 255" opacity_input="keys" rotation_input="scaled_channel" rotation_axis="0 0 1" uv_size="1 1" uv_offset_input="constant" uv_offset="0 0">
+                <size_scale_keys loop="false">
+                    <key t="0" v="0.30000001192093 0.30000001192093"/>
+                    <key t="0.018903592601418" v="1 1"/>
+                    <key t="0.12182740867138" v="3 3"/>
+                </size_scale_keys>
+                <opacity_keys loop="false">
+                    <key t="0.094517961144447" v="255"/>
+                    <key t="0.19289340078831" v="0"/>
+                </opacity_keys>
+                <rotation_scale_keys loop="false">
+                    <key t="0" v="0.10000000149012"/>
+                    <key t="1.8999999761581" v="0"/>
+                </rotation_scale_keys>
+            </billboard>
+        </visualizerstack>
+    </atom>
+    <atom name="Glow" min_size="1" max_size="1" lifetime="0.05" random_start_time="false" start_time="0" preroll="0" inherit_velocity_multiplier="1" fade_in_start="-1" fade_in_length="0" fade_out_start="20" spawn_cull_policy="initialize" cull_policy="freeze" cull_gracetime="0" max_particle_radius="-1" soundbank="" cue="" ambient="false" grab_relative="effect" grab_pos="0 0 0" grab_radius="200" grab_backfacing="false" timeline="">
+        <initializerstack>
+            <localboxrandomposition min="0 0 0" max="0 0 0"/>
+            <boxrandomcolor min="254.00001525879 158 95" max="253.00001525879 233.00001525879 213.00001525879"/>
+            <boxrandomsize min="40 40" max="60 60"/>
+            <boxrandomrotation relative="effect" min="-10 -10 1" max="10 10 1" min_rot="0" max_rot="365"/>
+        </initializerstack>
+        <simulatorstack>
+            <worldtransform transform_rotations="false"/>
+        </simulatorstack>
+        <visualizerstack>
+            <billboard texture="effects/textures/add_atlas_df" intensity="identity" billboard_type="camera_facing" rotation_channel="world_rotation" blend_mode="add" render_template="effect_op_halo" origo="0.5 0.5" per_particle_age="false" size_input="channel" color_input="constant" color="18 61.000003814697 20" opacity_input="keys" rotation_input="constant" rotation="0" rotation_axis="0 0 1" uv_size="0.125 0.03125" uv_offset_input="constant" uv_offset="0.75 0.125">
+                <opacity_keys loop="false">
+                    <key t="0" v="2"/>
+                    <key t="0.13884297013283" v="0"/>
+                </opacity_keys>
+            </billboard>
+        </visualizerstack>
+    </atom>
+    <atom name="locked_flash00" min_size="1" max_size="1" lifetime="0.02" random_start_time="false" start_time="0" preroll="0" inherit_velocity_multiplier="1" fade_in_start="-1" fade_in_length="0" fade_out_start="-1" spawn_cull_policy="kill" cull_policy="kill" cull_gracetime="0" max_particle_radius="-1" soundbank="" cue="" ambient="false" grab_relative="effect" grab_pos="0 0 0" grab_radius="200" grab_backfacing="false" timeline="">
+        <initializerstack>
+            <localboxrandomposition min="0 0 0" max="0 0 0"/>
+            <boxrandomvelocity relative="effect" min="0 0 0" max="0 0 0"/>
+            <boxrandomangle min="0" max="360"/>
+            <boxrandomrotation relative="effect" min="0 0.00010000000474975 0" max="0 0.00010000000474975 0" min_rot="0" max_rot="0"/>
+            <boxrandomuvoffset uv_size="0.0625 0.0625" frame_start="0 0.9375" primary_step_direction="+x" secondary_step_direction="+y" num_frames="4"/>
+            <boxrandomsize min="10 45" max="15 75"/>
+        </initializerstack>
+        <simulatorstack>
+            <worldtransform transform_rotations="false"/>
+            <velocityintegrator channel="world"/>
+        </simulatorstack>
+        <visualizerstack>
+            <billboard texture="effects/textures/effects_atlas" intensity="identity" billboard_type="normal_locked" rotation_channel="world_rotation" blend_mode="add" render_template="effect_op_glow" origo="0.5 1" per_particle_age="false" size_input="channel" color_input="keys" opacity_input="constant" opacity="150" rotation_input="constant" rotation="0" rotation_axis="0 0 0" uv_size="0.0625 0.0625" uv_offset_input="channel">
+                <color_keys loop="false">
+                    <key t="0" v="160 241 174"/>
+                    <key t="0.048192769289017" v="0 0 0"/>
+                </color_keys>
+            </billboard>
+        </visualizerstack>
+    </atom>
+    <atom name="smoke_forward" min_size="1" max_size="1.5" lifetime="0.8" random_start_time="false" start_time="0" preroll="0" inherit_velocity_multiplier="1" fade_in_start="-1" fade_in_length="0" fade_out_start="-1" spawn_cull_policy="kill" cull_policy="kill" cull_gracetime="0" max_particle_radius="-1" soundbank="" cue="" ambient="false" grab_relative="effect" grab_pos="0 0 0" grab_radius="200" grab_backfacing="false" timeline="">
+        <initializerstack>
+            <boxrandomvelocity relative="effect" min="0 50 0" max="0 100 0"/>
+            <boxrandomangle min="0" max="360"/>
+            <boxrandomrotation relative="effect" min="0 1 0" max="0 1 0" min_rot="0" max_rot="360"/>
+            <boxrandomuvoffset uv_size="0.25 0.0625" frame_start="0 0.0625" primary_step_direction="+x" secondary_step_direction="+y" num_frames="3"/>
+            <boxrandomaspectsize size="7 7" min="0.1" max="2"/>
+            <boxrandomposition relative="effect" min="-1 -1 -1" max="1 1 1"/>
+            <boxrandomanglevelocity min="-1.1" max="-1"/>
+        </initializerstack>
+        <simulatorstack>
+            <constantacceleration relative="world" acceleration="0 0 80"/>
+            <scaledvelocityintegrator channel="world" per_particle_age="false">
+                <scale_keys loop="false">
+                    <key t="0" v="5"/>
+                    <key t="0.18604651093483" v="1"/>
+                    <key t="0.33074936270714" v="0.69999998807907"/>
+                    <key t="0.6873385310173" v="0.10000000149012"/>
+                </scale_keys>
+            </scaledvelocityintegrator>
+            <anglevelocityintegrator/>
+        </simulatorstack>
+        <visualizerstack>
+            <billboard texture="effects/textures/opacity_atlas_df" intensity="identity" billboard_type="camera_facing" rotation_channel="world_rotation" blend_mode="normal" render_template="effect_op_add" origo="0.45 0.45" per_particle_age="false" size_input="scaled_channel" color_input="keys" opacity_input="keys" rotation_input="channel" rotation_axis="0 0 1" uv_size="0.125 0.0625" uv_offset_input="keys" frame_start="0 0" primary_step_direction="+x" secondary_step_direction="+y" num_frames="16" fps="36" loop="false">
+                <size_scale_keys loop="false">
+                    <key t="0" v="1 1"/>
+                    <key t="0.02702702768147" v="3 3"/>
+                    <key t="0.064864866435528" v="4 4"/>
+                    <key t="0.14594595134258" v="5 5"/>
+                </size_scale_keys>
+                <color_keys loop="false">
+                    <key t="0" v="14 118 19"/>
+                    <key t="3.4594595432281" v="0 0 0"/>
+                </color_keys>
+                <opacity_keys loop="false">
+                    <key t="0" v="0"/>
+                    <key t="0.032432433217764" v="40"/>
+                    <key t="0.19289340078831" v="20"/>
+                    <key t="0.89783281087875" v="0"/>
+                </opacity_keys>
+            </billboard>
+        </visualizerstack>
+    </atom>
+    <atom name="sparks1" min_size="1" max_size="1" lifetime="0.5" random_start_time="false" start_time="0" preroll="0" inherit_velocity_multiplier="1" fade_in_start="-1" fade_in_length="0" fade_out_start="-1" spawn_cull_policy="kill" cull_policy="kill" cull_gracetime="0" max_particle_radius="-1" soundbank="" cue="" ambient="false" grab_relative="effect" grab_pos="0 0 0" grab_radius="200" grab_backfacing="false" timeline="">
+        <initializerstack>
+            <boxrandomposition relative="effect" min="-1 -1 -1" max="1 1 1"/>
+            <boxrandomrotation relative="effect" min="0 0 0" max="0 0 0" min_rot="0" max_rot="0"/>
+            <boxrandomaspectsize size="1.2 24" min="1.3" max="2.3"/>
+            <boxrandomvelocity relative="effect" min="-40 2000 -40" max="40 2600 40"/>
+        </initializerstack>
+        <simulatorstack>
+            <rotationbyvelocity velocity="90000"/>
+            <velocityintegrator channel="world"/>
+            <constantacceleration relative="effect" acceleration="0 -1000 0"/>
+        </simulatorstack>
+        <visualizerstack>
+            <billboard texture="effects/textures/add_atlas_df" intensity="flashlight" billboard_type="normal_locked" rotation_channel="world_rotation" blend_mode="add" render_template="effect_op_halo" origo="0.5 0.9" per_particle_age="false" size_input="scaled_channel" color_input="constant" color="91 255 86" opacity_input="keys" rotation_input="constant" rotation="0" rotation_axis="0 0 1" uv_size="0.03125 0.0078125" uv_offset_input="constant" uv_offset="0.8125 0.1425">
+                <size_scale_keys loop="false">
+                    <key t="0" v="0.5 2"/>
+                    <key t="0.49916198849678" v="0.5 0.5"/>
+                </size_scale_keys>
+                <opacity_keys loop="false">
+                    <key t="0.35175880789757" v="255"/>
+                    <key t="0.5" v="0"/>
+                </opacity_keys>
+            </billboard>
+        </visualizerstack>
+    </atom>
+</effect>

--- a/lua/weaponfactorytweakdata.lua
+++ b/lua/weaponfactorytweakdata.lua
@@ -1716,45 +1716,45 @@ function WeaponFactoryTweakData:_balance_shotgun_ammo(tweak_data)
 		wpn_fps_upg_a_custom = {
 			very_heavy = { -- double barrels
 				stats = { damage = 12, recoil = -3 },
-				custom_stats = { rays = 6, damage_near_mul = 0.5 },
+				custom_stats = { rays = 6, damage_near_mul = 0.5, muzzleflash = "effects/particles/weapons/sho_buckshot" },
 			},
 			heavy = { -- shotguns like gsps and the trench gun
 				stats = { damage = 10, recoil = -3 },
-				custom_stats = { rays = 6, damage_near_mul = 0.5 },
+				custom_stats = { rays = 6, damage_near_mul = 0.5, muzzleflash = "effects/particles/weapons/sho_buckshot" },
 			},
 			medium = { -- raven, loco, reinfeld, etc
 				stats = { damage = 8, recoil = -3 },
-				custom_stats = { rays = 6, damage_near_mul = 0.5 },
+				custom_stats = { rays = 6, damage_near_mul = 0.5, muzzleflash = "effects/particles/weapons/sho_buckshot" },
 			},
 			light = { -- semi autos
 				stats = { damage = 6, recoil = -3 },
-				custom_stats = { rays = 6, damage_near_mul = 0.5 },
+				custom_stats = { rays = 6, damage_near_mul = 0.5, muzzleflash = "effects/particles/weapons/sho_buckshot" },
 			},
 			very_light = { -- full autos
 				stats = { damage = 6, recoil = -3 },
-				custom_stats = { rays = 6, damage_near_mul = 0.5 },
+				custom_stats = { rays = 6, damage_near_mul = 0.5, muzzleflash = "effects/particles/weapons/sho_buckshot" },
 			},
 		},
 		wpn_fps_upg_a_custom_free = {
 			very_heavy = { -- double barrels
 				stats = { damage = 12, recoil = -3 },
-				custom_stats = { rays = 6, damage_near_mul = 0.5 },
+				custom_stats = { rays = 6, damage_near_mul = 0.5, muzzleflash = "effects/particles/weapons/sho_buckshot" },
 			},
 			heavy = { -- shotguns like gsps and the trench gun
 				stats = { damage = 10, recoil = -3 },
-				custom_stats = { rays = 6, damage_near_mul = 0.5 },
+				custom_stats = { rays = 6, damage_near_mul = 0.5, muzzleflash = "effects/particles/weapons/sho_buckshot" },
 			},
 			medium = { -- raven, loco, reinfeld, etc
 				stats = { damage = 8, recoil = -3 },
-				custom_stats = { rays = 6, damage_near_mul = 0.5 },
+				custom_stats = { rays = 6, damage_near_mul = 0.5, muzzleflash = "effects/particles/weapons/sho_buckshot" },
 			},
 			light = { -- semi autos
 				stats = { damage = 6, recoil = -3 },
-				custom_stats = { rays = 6, damage_near_mul = 0.5 },
+				custom_stats = { rays = 6, damage_near_mul = 0.5, muzzleflash = "effects/particles/weapons/sho_buckshot" },
 			},
 			very_light = { -- full autos
 				stats = { damage = 6, recoil = -3 },
-				custom_stats = { rays = 6, damage_near_mul = 0.5 },
+				custom_stats = { rays = 6, damage_near_mul = 0.5, muzzleflash = "effects/particles/weapons/sho_buckshot" },
 			},
 		},
 		wpn_fps_upg_a_explosive = {
@@ -1769,6 +1769,7 @@ function WeaponFactoryTweakData:_balance_shotgun_ammo(tweak_data)
 					bullet_class = "InstantExplosiveBulletBase",
 					damage_near_mul = 10,
 					rays = 1,
+					muzzleflash = "effects/payday2/particles/weapons/big_762_auto_fps",
 				},
 			},
 			heavy = { -- shotguns like gsps and the trench gun
@@ -1782,6 +1783,7 @@ function WeaponFactoryTweakData:_balance_shotgun_ammo(tweak_data)
 					bullet_class = "InstantExplosiveBulletBase",
 					damage_near_mul = 10,
 					rays = 1,
+					muzzleflash = "effects/payday2/particles/weapons/big_762_auto_fps",
 				},
 			},
 			medium = { -- raven, loco, reinfeld, etc
@@ -1795,6 +1797,7 @@ function WeaponFactoryTweakData:_balance_shotgun_ammo(tweak_data)
 					bullet_class = "InstantExplosiveBulletBase",
 					damage_near_mul = 10,
 					rays = 1,
+					muzzleflash = "effects/payday2/particles/weapons/big_762_auto_fps",
 				},
 			},
 			light = { -- semi autos
@@ -1808,6 +1811,7 @@ function WeaponFactoryTweakData:_balance_shotgun_ammo(tweak_data)
 					bullet_class = "InstantExplosiveBulletBase",
 					damage_near_mul = 10,
 					rays = 1,
+					muzzleflash = "effects/payday2/particles/weapons/big_762_auto_fps",
 				},
 			},
 			very_light = { -- full autos
@@ -1821,6 +1825,7 @@ function WeaponFactoryTweakData:_balance_shotgun_ammo(tweak_data)
 					bullet_class = "InstantExplosiveBulletBase",
 					damage_near_mul = 10,
 					rays = 1,
+					muzzleflash = "effects/payday2/particles/weapons/big_762_auto_fps",
 				},
 			},
 		},
@@ -1836,6 +1841,7 @@ function WeaponFactoryTweakData:_balance_shotgun_ammo(tweak_data)
 					damage_near_mul = 10,
 					rays = 1,
 					check_additional_achievements = true,
+					muzzleflash = "effects/payday2/particles/weapons/50cal_auto_fps",
 				},
 			},
 			heavy = { -- shotguns like gsps and the trench gun
@@ -1849,6 +1855,7 @@ function WeaponFactoryTweakData:_balance_shotgun_ammo(tweak_data)
 					damage_near_mul = 10,
 					rays = 1,
 					check_additional_achievements = true,
+					muzzleflash = "effects/payday2/particles/weapons/50cal_auto_fps",
 				},
 			},
 			medium = { -- raven, loco, reinfeld, etc
@@ -1862,6 +1869,7 @@ function WeaponFactoryTweakData:_balance_shotgun_ammo(tweak_data)
 					damage_near_mul = 10,
 					rays = 1,
 					check_additional_achievements = true,
+					muzzleflash = "effects/payday2/particles/weapons/50cal_auto_fps",
 				},
 			},
 			light = { -- semi autos
@@ -1875,6 +1883,7 @@ function WeaponFactoryTweakData:_balance_shotgun_ammo(tweak_data)
 					damage_near_mul = 10,
 					rays = 1,
 					check_additional_achievements = true,
+					muzzleflash = "effects/payday2/particles/weapons/50cal_auto_fps",
 				},
 			},
 			very_light = { -- full autos
@@ -1888,6 +1897,7 @@ function WeaponFactoryTweakData:_balance_shotgun_ammo(tweak_data)
 					damage_near_mul = 10,
 					rays = 1,
 					check_additional_achievements = true,
+					muzzleflash = "effects/payday2/particles/weapons/50cal_auto_fps",
 				},
 			},
 		},
@@ -1898,6 +1908,7 @@ function WeaponFactoryTweakData:_balance_shotgun_ammo(tweak_data)
 					rays = 12,
 					armor_piercing_add = 1,
 					can_shoot_through_enemy = true,
+					muzzleflash = "effects/particles/weapons/sho_flechette",
 				},
 			},
 			heavy = { -- shotguns like gsps and the trench gun
@@ -1906,6 +1917,7 @@ function WeaponFactoryTweakData:_balance_shotgun_ammo(tweak_data)
 					rays = 12,
 					armor_piercing_add = 1,
 					can_shoot_through_enemy = true,
+					muzzleflash = "effects/particles/weapons/sho_flechette",
 				},
 			},
 			medium = { -- raven, loco, reinfeld, etc
@@ -1914,6 +1926,7 @@ function WeaponFactoryTweakData:_balance_shotgun_ammo(tweak_data)
 					rays = 12,
 					armor_piercing_add = 1,
 					can_shoot_through_enemy = true,
+					muzzleflash = "effects/particles/weapons/sho_flechette",
 				},
 			},
 			light = { -- semi autos
@@ -1922,6 +1935,7 @@ function WeaponFactoryTweakData:_balance_shotgun_ammo(tweak_data)
 					rays = 12,
 					armor_piercing_add = 1,
 					can_shoot_through_enemy = true,
+					muzzleflash = "effects/particles/weapons/sho_flechette",
 				},
 			},
 			very_light = { -- full autos
@@ -1930,6 +1944,7 @@ function WeaponFactoryTweakData:_balance_shotgun_ammo(tweak_data)
 					rays = 12,
 					armor_piercing_add = 1,
 					can_shoot_through_enemy = true,
+					muzzleflash = "effects/particles/weapons/sho_flechette",
 				},
 			},
 		},
@@ -2002,7 +2017,7 @@ function WeaponFactoryTweakData:_balance_shotgun_ammo(tweak_data)
 					ammo_pickup_min_mul = 0.6,
 					ammo_pickup_max_mul = 0.6,
 					armor_piercing_add = 1,
-					muzzleflash = "effects/payday2/particles/weapons/shotgun/sho_muzzleflash_rip",
+					muzzleflash = "effects/particles/weapons/sho_tomb",
 					dot_data_name = "ammo_rip",
 					stance_mul = slug_stance_muls,
 					damage_near_mul = 10,
@@ -2016,7 +2031,7 @@ function WeaponFactoryTweakData:_balance_shotgun_ammo(tweak_data)
 					ammo_pickup_min_mul = 0.6,
 					ammo_pickup_max_mul = 0.6,
 					armor_piercing_add = 1,
-					muzzleflash = "effects/payday2/particles/weapons/shotgun/sho_muzzleflash_rip",
+					muzzleflash = "effects/particles/weapons/sho_tomb",
 					dot_data_name = "ammo_rip",
 					stance_mul = slug_stance_muls,
 					damage_near_mul = 10,
@@ -2030,7 +2045,7 @@ function WeaponFactoryTweakData:_balance_shotgun_ammo(tweak_data)
 					ammo_pickup_min_mul = 0.6,
 					ammo_pickup_max_mul = 0.6,
 					armor_piercing_add = 1,
-					muzzleflash = "effects/payday2/particles/weapons/shotgun/sho_muzzleflash_rip",
+					muzzleflash = "effects/particles/weapons/sho_tomb",
 					dot_data_name = "ammo_rip",
 					stance_mul = slug_stance_muls,
 					damage_near_mul = 10,
@@ -2044,7 +2059,7 @@ function WeaponFactoryTweakData:_balance_shotgun_ammo(tweak_data)
 					ammo_pickup_min_mul = 0.6,
 					ammo_pickup_max_mul = 0.6,
 					armor_piercing_add = 1,
-					muzzleflash = "effects/payday2/particles/weapons/shotgun/sho_muzzleflash_rip",
+					muzzleflash = "effects/particles/weapons/sho_tomb",
 					dot_data_name = "ammo_rip",
 					stance_mul = slug_stance_muls,
 					damage_near_mul = 10,
@@ -2058,7 +2073,7 @@ function WeaponFactoryTweakData:_balance_shotgun_ammo(tweak_data)
 					ammo_pickup_min_mul = 0.6,
 					ammo_pickup_max_mul = 0.6,
 					armor_piercing_add = 1,
-					muzzleflash = "effects/payday2/particles/weapons/shotgun/sho_muzzleflash_rip",
+					muzzleflash = "effects/particles/weapons/sho_tomb",
 					dot_data_name = "ammo_rip",
 					stance_mul = slug_stance_muls,
 					damage_near_mul = 10,

--- a/lua/weapontweakdata.lua
+++ b/lua/weapontweakdata.lua
@@ -2006,6 +2006,7 @@ Hooks:PostHook(WeaponTweakData, "init", "eclipse_init", function(self, tweak_dat
 	self.saiga.stats.recoil = 12
 	self.saiga.stats.concealment = 17
 	self.saiga.fire_mode_data.fire_rate = 60 / 350
+	self.saiga.muzzleflash = "effects/particles/weapons/sho_default"
 
 	-- Street Sweeper
 	self.striker.CLIP_AMMO_MAX = 12
@@ -2015,6 +2016,7 @@ Hooks:PostHook(WeaponTweakData, "init", "eclipse_init", function(self, tweak_dat
 	self.striker.stats.concealment = 23
 	self.striker.fire_mode_data.fire_rate = 60 / 450
 	self.striker.reload_speed_multiplier = 1.3
+	self.striker.muzzleflash = "effects/particles/weapons/sho_default"
 
 	-- Steakout
 	self.aa12.CLIP_AMMO_MAX = 8
@@ -2023,6 +2025,7 @@ Hooks:PostHook(WeaponTweakData, "init", "eclipse_init", function(self, tweak_dat
 	self.aa12.stats.recoil = 14
 	self.aa12.stats.concealment = 15
 	self.aa12.fire_mode_data.fire_rate = 60 / 300
+	self.aa12.muzzleflash = "effects/particles/weapons/sho_default"
 
 	-- Grimm
 	self.basset.CLIP_AMMO_MAX = 7
@@ -2031,6 +2034,7 @@ Hooks:PostHook(WeaponTweakData, "init", "eclipse_init", function(self, tweak_dat
 	self.basset.stats.recoil = 13
 	self.basset.stats.concealment = 24
 	self.basset.fire_mode_data.fire_rate = 60 / 350
+	self.basset.muzzleflash = "effects/particles/weapons/sho_default"
 
 	-- M1014
 	self.benelli.CLIP_AMMO_MAX = 8
@@ -2039,6 +2043,7 @@ Hooks:PostHook(WeaponTweakData, "init", "eclipse_init", function(self, tweak_dat
 	self.benelli.stats.recoil = 10
 	self.benelli.stats.concealment = 17
 	self.benelli.fire_mode_data.fire_rate = 60 / 300
+	self.benelli.muzzleflash = "effects/particles/weapons/sho_default"
 
 	-- Predator
 	self.spas12.CLIP_AMMO_MAX = 8
@@ -2047,6 +2052,7 @@ Hooks:PostHook(WeaponTweakData, "init", "eclipse_init", function(self, tweak_dat
 	self.spas12.stats.recoil = 12
 	self.spas12.stats.concealment = 19
 	self.spas12.fire_mode_data.fire_rate = 60 / 300
+	self.spas12.muzzleflash = "effects/particles/weapons/sho_default"
 
 	-- Goliath
 	self.rota.upgrade_blocks = { -- No mag size increases
@@ -2060,6 +2066,7 @@ Hooks:PostHook(WeaponTweakData, "init", "eclipse_init", function(self, tweak_dat
 	self.rota.stats.recoil = 8
 	self.rota.stats.concealment = 22
 	self.rota.fire_mode_data.fire_rate = 60 / 300
+	self.rota.muzzleflash = "effects/particles/weapons/sho_default"
 
 	-- Argos
 	self.ultima.use_data.selection_index = 2
@@ -2070,6 +2077,7 @@ Hooks:PostHook(WeaponTweakData, "init", "eclipse_init", function(self, tweak_dat
 	self.ultima.stats.concealment = 21
 	self.ultima.fire_mode_data.fire_rate = 60 / 300
 	self.ultima.reload_speed_multiplier = 0.7
+	self.ultima.muzzleflash = "effects/particles/weapons/sho_default"
 
 	-- VD-12
 	self.sko12.CLIP_AMMO_MAX = 25
@@ -2081,6 +2089,7 @@ Hooks:PostHook(WeaponTweakData, "init", "eclipse_init", function(self, tweak_dat
 	self.sko12.reload_speed_multiplier = 0.7
 	self.sko12.FIRE_MODE = "single"
 	self.sko12.CAN_TOGGLE_FIREMODE = false
+	self.sko12.muzzleflash = "effects/particles/weapons/sho_default"
 
 	-- Reinfeld 880
 	self.r870.CLIP_AMMO_MAX = 8
@@ -2089,6 +2098,7 @@ Hooks:PostHook(WeaponTweakData, "init", "eclipse_init", function(self, tweak_dat
 	self.r870.stats.recoil = 10
 	self.r870.stats.concealment = 17
 	self.r870.fire_mode_data.fire_rate = 60 / 120
+	self.r870.muzzleflash = "effects/particles/weapons/sho_default"
 
 	-- Loco
 	self.serbu.CLIP_AMMO_MAX = 4
@@ -2098,6 +2108,7 @@ Hooks:PostHook(WeaponTweakData, "init", "eclipse_init", function(self, tweak_dat
 	self.serbu.stats.concealment = 23
 	self.serbu.fire_mode_data.fire_rate = 60 / 120
 	self.serbu.fire_rate_multiplier = 150 / 120
+	self.serbu.muzzleflash = "effects/particles/weapons/sho_default"
 
 	-- Raven
 	self.ksg.CLIP_AMMO_MAX = 14
@@ -2107,6 +2118,7 @@ Hooks:PostHook(WeaponTweakData, "init", "eclipse_init", function(self, tweak_dat
 	self.ksg.stats.concealment = 22
 	self.ksg.fire_mode_data.fire_rate = 60 / 120
 	self.ksg.fire_rate_multiplier = 90 / 120
+	self.ksg.muzzleflash = "effects/particles/weapons/sho_default"
 
 	-- Mosconi Tactical
 	self.m590.CLIP_AMMO_MAX = 7
@@ -2116,6 +2128,7 @@ Hooks:PostHook(WeaponTweakData, "init", "eclipse_init", function(self, tweak_dat
 	self.m590.stats.concealment = 19
 	self.m590.fire_mode_data.fire_rate = 60 / 120
 	self.m590.fire_rate_multiplier = 135 / 120
+	self.m590.muzzleflash = "effects/particles/weapons/sho_default"
 
 	-- Judge
 	self.judge.CLIP_AMMO_MAX = 5
@@ -2124,6 +2137,7 @@ Hooks:PostHook(WeaponTweakData, "init", "eclipse_init", function(self, tweak_dat
 	self.judge.stats.recoil = 8
 	self.judge.stats.concealment = 28
 	self.judge.fire_mode_data.fire_rate = 60 / 300
+	self.judge.muzzleflash = "effects/particles/weapons/sho_default"
 
     self.x_judge.weapon_hold = "x_chinchilla"
     self.x_judge.animations.reload_name_id = "x_chinchilla"
@@ -2135,6 +2149,7 @@ Hooks:PostHook(WeaponTweakData, "init", "eclipse_init", function(self, tweak_dat
 		wp_chinchilla_insert = "wp_rbull_shells_in",
 		wp_chinchilla_cylinder_in = "wp_rbull_drum_close"
 	}
+	self.x_judge.muzzleflash = "effects/particles/weapons/sho_default"
 
 	-- GSPS
 	self.m37.CLIP_AMMO_MAX = 5
@@ -2144,6 +2159,7 @@ Hooks:PostHook(WeaponTweakData, "init", "eclipse_init", function(self, tweak_dat
 	self.m37.stats.concealment = 19
 	self.m37.fire_mode_data.fire_rate = 60 / 100
 	self.m37.fire_rate_multiplier = 105 / 100
+	self.m37.muzzleflash = "effects/particles/weapons/sho_default"
 
 	-- Reinfeld 88
 	self.m1897.CLIP_AMMO_MAX = 7
@@ -2153,6 +2169,7 @@ Hooks:PostHook(WeaponTweakData, "init", "eclipse_init", function(self, tweak_dat
 	self.m1897.stats.concealment = 18
 	self.m1897.fire_mode_data.fire_rate = 60 / 100
 	self.m1897.fire_rate_multiplier = 120 / 100
+	self.m1897.muzzleflash = "effects/particles/weapons/sho_default"
 
 	-- Nova
 	self.supernova.CLIP_AMMO_MAX = 5
@@ -2163,6 +2180,7 @@ Hooks:PostHook(WeaponTweakData, "init", "eclipse_init", function(self, tweak_dat
 	self.supernova.fire_mode_data.fire_rate = 60 / 90
 	self.supernova.fire_rate_multiplier = 105 / 90
 	self.supernova.alt_fire_data = nil
+	self.supernova.muzzleflash = "effects/particles/weapons/sho_default"
 
 	-- Mosconi
 	self.huntsman.CLIP_AMMO_MAX = 2
@@ -2171,6 +2189,7 @@ Hooks:PostHook(WeaponTweakData, "init", "eclipse_init", function(self, tweak_dat
 	self.huntsman.stats.recoil = 6
 	self.huntsman.stats.concealment = 15
 	self.huntsman.fire_mode_data.fire_rate = 60 / 500
+	self.huntsman.muzzleflash = "effects/particles/weapons/sho_default"
 
 	-- Joceline
 	self.b682.CLIP_AMMO_MAX = 2
@@ -2179,6 +2198,7 @@ Hooks:PostHook(WeaponTweakData, "init", "eclipse_init", function(self, tweak_dat
 	self.b682.stats.recoil = 4
 	self.b682.stats.concealment = 15
 	self.b682.fire_mode_data.fire_rate = 60 / 500
+	self.b682.muzzleflash = "effects/particles/weapons/sho_default"
 
 	-- Breaker
 	self.boot.CLIP_AMMO_MAX = 6
@@ -2187,6 +2207,7 @@ Hooks:PostHook(WeaponTweakData, "init", "eclipse_init", function(self, tweak_dat
 	self.boot.stats.recoil = 3
 	self.boot.stats.concealment = 20
 	self.boot.fire_mode_data.fire_rate = 60 / 60
+	self.boot.muzzleflash = "effects/particles/weapons/sho_default"
 
 	-- Claire
 	self.coach.CLIP_AMMO_MAX = 2
@@ -2821,17 +2842,22 @@ Hooks:PostHook(WeaponTweakData, "init", "eclipse_init_npcweapons", function(self
 
 	self.sr2_smg_npc.sounds.prefix = self.sr2_crew.sounds.prefix
 
+	self.r870_npc.muzzleflash = "effects/payday2/particles/weapons/shotgun/sho_muzzleflash"
 	self.r870_yellow_npc = deep_clone(self.r870_npc)
+	self.r870_yellow_npc.muzzleflash = "effects/payday2/particles/weapons/shotgun/sho_muzzleflash"
 
 	self.benelli_npc = copy_data(self.benelli_npc, self.r870_npc, self.ben_crew)
+	self.benelli_npc.muzzleflash = "effects/payday2/particles/weapons/shotgun/sho_muzzleflash"
 
 	self.mossberg_npc.usage = "is_double_barrel"
 	self.mossberg_npc.reload = "looped"
 	self.mossberg_npc.looped_reload_single = true
 
 	self.saiga_npc.CLIP_AMMO_MAX = 20
+	self.saiga_npc.muzzleflash = "effects/payday2/particles/weapons/shotgun/sho_muzzleflash"
 
 	self.aa12_npc = copy_data(self.aa12_npc, self.saiga_npc, self.aa12_crew)
+	self.aa12_npc.muzzleflash = "effects/payday2/particles/weapons/shotgun/sho_muzzleflash"
 
 	self.sko12_conc_npc = copy_data(self.sko12_conc_npc, self.saiga_npc, self.sko12_crew)
 	self.sko12_conc_npc.bullet_class = nil

--- a/supermod.xml
+++ b/supermod.xml
@@ -293,6 +293,12 @@
 	</hooks>
 
 	<assets base_path="assets/">
+		<!-- shotgun ammo types -->
+		<file name="effects/particles/weapons/sho_buckshot.effect"/>
+		<file name="effects/particles/weapons/sho_default.effect"/>
+		<file name="effects/particles/weapons/sho_flechette.effect"/>
+		<file name="effects/particles/weapons/sho_tomb.effect"/>
+	
 		<!-- sniper glare -->
 		<file name="effects/particles/weapons/sniper_glint.effect"/>
 		<file name="effects/particles/weapons/elite_sniper_glint.effect"/>


### PR DESCRIPTION
Just like the title, it gives each ammo type its own particles by reusing an unused effect. Purely for visual fun.
It also assigns the unused effect to NPC weapons, crew weapons will come later.

Video preview: (eclipse server)
https://discord.com/channels/1328403205406589061/1343650794142040134/1431673486614728785