### PR TITLE
It's on the table (Remove JC checks for difficulties)

### DIFF
--- a/lua/menumanager.lua
+++ b/lua/menumanager.lua
@@ -24,7 +24,7 @@ function MenuCallbackHandler:is_contract_difficulty_allowed(item)
 	local plvl = managers.experience:current_level()
 	local level_lock = tweak_data.difficulty_level_locks[item:value()] or 0
 	local is_not_level_locked = plvl >= level_lock
-	return is_not_level_locked and managers.job:get_max_jc_for_player() >= math.clamp(job_jc + difficulty_jc, 0, 100)
+	return is_not_level_locked
 end
 
 function MenuCrimeNetFiltersInitiator:update_node(node)


### PR DESCRIPTION
Listens to tweak_data.difficulty_level_locks table instead of whatever the previous calculation was supposed to be, allowing you to buy a Hard contract at level 0 eventhough you can't because of lack of offshore cash.