### PR TITLE
Revert Crimefest 2015

### DIFF
--- a/lua/ingamelobbymenu.lua
+++ b/lua/ingamelobbymenu.lua
@@ -47,3 +47,10 @@ function IngameLobbyMenuState:at_enter()
 		end
 	end
 end
+
+-- These two functions disable (or at least should disable) query for a callback from Steam regarding a skin drop
+function IngameLobbyMenuState:_set_lootdrop()
+	self:set_lootdrop()
+end
+
+function IngameLobbyMenuState:_clbk_inventory_reward() end


### PR DESCRIPTION
Disables skin drop query to Steam (or at least it should) to fix the infinite waiting for a response at card drops.
This might prevent you from getting skin drops when playing Eclipse, but they're all useless, worthless and ugly anyway so who cares.