### PR TITLE
The house always wins

### DIFF
--- a/lua/tweakdata.lua
+++ b/lua/tweakdata.lua
@@ -399,6 +399,42 @@ if tweak_data.blackmarket.xp.xp_pda9_1 then
 	}
 end
 
+tweak_data.casino = {
+	unlock_level = 10,
+	entrance_level = {
+		14,
+		28,
+		40,
+		45,
+		55,
+		65,
+		75
+	},
+	entrance_fee = {
+		300000,
+		300000,
+		300000,
+		300000,
+		300000,
+		350000,
+		400000
+	},
+	prefer_cost = 500000,
+	prefer_chance = 0.1,
+	secure_card_cost = {
+		250000,
+		500000,
+		750000
+	},
+	secure_card_level = {
+		10,
+		40,
+		60
+	},
+	infamous_cost = 2500000,
+	infamous_chance = 3
+}
+
 -- misc
 -- Python code for matplotlibing experience graphs
 --[[


### PR DESCRIPTION
Cost per roll is 300.000$ offshore
Increases to 350.000$ at level 65
and 400.000$ at level 75
Choosing a preferred card type costs 500.000$
Securing cards costs 250.000$, 500.000$, 750.000$ respectively.

https://github.com/user-attachments/assets/ae84fb87-3fcb-4874-bc3a-5fb3e13040d3

