### PR TITLE
Sanitize small_loot stuff

### DIFF
--- a/lua/moneytweakdata.lua
+++ b/lua/moneytweakdata.lua
@@ -671,7 +671,36 @@ function MoneyTweakData:init(tweak_data)
 		1.4,
 	})
 	self.small_loot = {}
+	self.small_loot.money_bundle = (money_mul * 750)
+	self.small_loot.money_bundle_value = (money_mul * 10000)
+	self.small_loot.ring_band = 1954
+	self.small_loot.diamondheist_vault_bust = (money_mul * 4750)
+	self.small_loot.diamondheist_vault_diamond = (money_mul * 6250)
+	self.small_loot.diamondheist_big_diamond = (money_mul * 9000)
+	self.small_loot.mus_small_artifact = (money_mul * 700)
+	self.small_loot.value_gold = (money_mul * 10000)
+	self.small_loot.gen_atm = (money_mul * 36000)
+	self.small_loot.special_deposit_box = (money_mul * 3500)
+	self.small_loot.slot_machine_payout = (money_mul * 75000)
+	self.small_loot.vault_loot_chest = (money_mul * 9000)
+	self.small_loot.vault_loot_diamond_chest = (money_mul * 14000)
+	self.small_loot.vault_loot_banknotes = (money_mul * 9000)
+	self.small_loot.vault_loot_silver = (money_mul * 9650)
+	self.small_loot.vault_loot_diamond_collection = (money_mul * 11500)
+	self.small_loot.vault_loot_trophy = (money_mul * 12500)
+	self.small_loot.money_wrap_single_bundle_vscaled = (money_mul * 385)
+	self.small_loot.spawn_bucket_of_money = (money_mul * 20000)
+	self.small_loot.vault_loot_gold = (money_mul * 17500)
+	self.small_loot.vault_loot_cash = (money_mul * 2500)
+	self.small_loot.vault_loot_coins = (money_mul * 1800)
+	self.small_loot.vault_loot_ring = (money_mul * 6000)
+	self.small_loot.vault_loot_jewels = (money_mul * 1400)
+	self.small_loot.vault_loot_macka = 1
+	self.small_loot.federali_medal = 769
+
+	-- Heist specific loot values
 	if level_id == "big" then
+		self.bag_values.money = 75000
 		self.small_loot.money_bundle = (money_mul * 1000)
 		self.small_loot.money_bundle_value = (money_mul * 10000)
 		self.small_loot.value_gold = (money_mul * 1000)
@@ -687,46 +716,23 @@ function MoneyTweakData:init(tweak_data)
 		self.small_loot.vault_loot_coins = (money_mul * 1800)
 		self.small_loot.vault_loot_ring = (money_mul * 6000)
 		self.small_loot.vault_loot_jewels = (money_mul * 1400)
-	elseif level_id == "watchdogs_2" or level_id == "watchdogs_2_day" then
-		self.small_loot.money_bundle = (money_mul * 50000)
-	elseif level_id == "dah" then
+	end
+	if level_id == "watchdogs_2" or level_id == "watchdogs_2_day" then
+		self.small_loot.money_bundle = 50000
+	end
+	if level_id == "dah" then
 		self.small_loot.diamondheist_vault_bust = 50000
 		self.small_loot.diamondheist_vault_diamond = 15000
 		self.small_loot.diamondheist_big_diamond = 25000
-	elseif level_id == "red2" or level_id == "kenaz" then
+	end
+	if level_id == "red2" or level_id == "kenaz" then
 		self.bag_values.money = 90000 -- 90,000$
-		self.small_loot.gen_atm = (money_mul * 72000)
+		self.small_loot.gen_atm = (money_mul * 36000)
 		self.small_loot.money_bundle = (money_mul * 8250)
-	elseif level_id == "dinner" then
+	end
+	if level_id == "dinner" then
 		self.bag_values.gold = 350000 -- 350,000$
 		self.small_loot.money_bundle = (money_mul * 10250)
-	else
-		self.small_loot.money_bundle = (money_mul * 750)
-		self.small_loot.money_bundle_value = (money_mul * 10000)
-		self.small_loot.ring_band = 1954
-		self.small_loot.diamondheist_vault_bust = (money_mul * 4750)
-		self.small_loot.diamondheist_vault_diamond = (money_mul * 6250)
-		self.small_loot.diamondheist_big_diamond = (money_mul * 9000)
-		self.small_loot.mus_small_artifact = (money_mul * 700)
-		self.small_loot.value_gold = (money_mul * 10000)
-		self.small_loot.gen_atm = (money_mul * 36000)
-		self.small_loot.special_deposit_box = (money_mul * 3500)
-		self.small_loot.slot_machine_payout = (money_mul * 75000)
-		self.small_loot.vault_loot_chest = (money_mul * 9000)
-		self.small_loot.vault_loot_diamond_chest = (money_mul * 14000)
-		self.small_loot.vault_loot_banknotes = (money_mul * 9000)
-		self.small_loot.vault_loot_silver = (money_mul * 9650)
-		self.small_loot.vault_loot_diamond_collection = (money_mul * 11500)
-		self.small_loot.vault_loot_trophy = (money_mul * 12500)
-		self.small_loot.money_wrap_single_bundle_vscaled = (money_mul * 385)
-		self.small_loot.spawn_bucket_of_money = (money_mul * 20000)
-		self.small_loot.vault_loot_gold = (money_mul * 17500)
-		self.small_loot.vault_loot_cash = (money_mul * 2500)
-		self.small_loot.vault_loot_coins = (money_mul * 1800)
-		self.small_loot.vault_loot_ring = (money_mul * 6000)
-		self.small_loot.vault_loot_jewels = (money_mul * 1400)
-		self.small_loot.vault_loot_macka = 1
-		self.small_loot.federali_medal = 769
 	end
 
 	self.max_small_loot_value = 20000000


### PR DESCRIPTION
This'll prevent crashes if a loot value isn't defined for a specific level.
I don't know why I didn't do it this way much earlier.