### PR TITLE
Fix stale GroupAI area data neighbours

### DIFF
--- a/lua/groupaistatebase.lua
+++ b/lua/groupaistatebase.lua
@@ -570,8 +570,7 @@ end)
 -- The function only modifies bidirectional neighbours to point to the newly created area
 -- Leaving stale neighbours entries if there was an existing one-way link due to navlinks
 Hooks:PostHook(GroupAIStateBase, "add_area", "eclipse_add_area", function(self, area_id, nav_segs)
-	local all_areas = self._area_data
-	local new_area = all_areas[area_id]
+	local new_area = self._area_data[area_id]
 	if not new_area then
 		return
 	end
@@ -581,7 +580,7 @@ Hooks:PostHook(GroupAIStateBase, "add_area", "eclipse_add_area", function(self, 
 		local nav_seg = all_nav_segs[seg_id]
 		if nav_seg and not nav_seg.disabled then
 			for other_seg_id, other_nav_seg in pairs(all_nav_segs) do
-				if not other_nav_seg.disabled and other_nav_seg.neighbours[seg_id] and not nav_seg.neighbours[other_seg_id] then -- recompute one-directional links
+				if not other_nav_seg.disabled and not new_area.nav_segs[other_seg_id] and other_nav_seg.neighbours[seg_id] and not nav_seg.neighbours[other_seg_id] then -- recompute one-directional links
 					self:on_nav_seg_neighbour_state(other_seg_id, seg_id, true)
 				end
 			end

--- a/lua/groupaistatebase.lua
+++ b/lua/groupaistatebase.lua
@@ -566,6 +566,26 @@ Hooks:PostHook(GroupAIStateBase, "on_enemy_unregistered", "sh_on_enemy_unregiste
 	e_data.spawn_group.delay_t = math.max(e_data.spawn_group.delay_t, delay_t)
 end)
 
+-- Fix stale neighbours entries when creating AI Areas
+-- The function only modifies bidirectional neighbours to point to the newly created area
+-- Leaving stale neighbours entries if there was an existing one-way link due to navlinks
+Hooks:PostHook(GroupAIStateBase, "add_area", "eclipse_add_area", function(self, area_id, nav_segs, area_pos)
+	local all_areas = self._area_data
+	local new_area = all_areas[area_id]
+	if not new_area then
+		return
+	end
+
+	for _, other_area in pairs(all_areas) do
+		for _, seg_id in ipairs(nav_segs) do
+			if other_area.neighbours[seg_id] then
+				other_area.neighbours[seg_id] = nil
+				other_area.neighbours[new_area.id] = new_area
+			end
+		end
+	end
+end)
+
 -- Fix this function doing nothing
 function GroupAIStateBase:_merge_coarse_path_by_area(coarse_path)
 	local i_nav_seg = #coarse_path

--- a/lua/groupaistatebase.lua
+++ b/lua/groupaistatebase.lua
@@ -569,18 +569,21 @@ end)
 -- Fix stale neighbours entries when creating AI Areas
 -- The function only modifies bidirectional neighbours to point to the newly created area
 -- Leaving stale neighbours entries if there was an existing one-way link due to navlinks
-Hooks:PostHook(GroupAIStateBase, "add_area", "eclipse_add_area", function(self, area_id, nav_segs, area_pos)
+Hooks:PostHook(GroupAIStateBase, "add_area", "eclipse_add_area", function(self, area_id, nav_segs)
 	local all_areas = self._area_data
 	local new_area = all_areas[area_id]
 	if not new_area then
 		return
 	end
 
-	for _, other_area in pairs(all_areas) do
-		for _, seg_id in ipairs(nav_segs) do
-			if other_area.neighbours[seg_id] then
-				other_area.neighbours[seg_id] = nil
-				other_area.neighbours[new_area.id] = new_area
+	local all_nav_segs = managers.navigation._nav_segments
+	for _, seg_id in ipairs(nav_segs) do
+		local nav_seg = all_nav_segs[seg_id]
+		if nav_seg and not nav_seg.disabled then
+			for other_seg_id, other_nav_seg in pairs(all_nav_segs) do
+				if not other_nav_seg.disabled and other_nav_seg.neighbours[seg_id] and not nav_seg.neighbours[other_seg_id] then -- recompute one-directional links
+					self:on_nav_seg_neighbour_state(other_seg_id, seg_id, true)
+				end
 			end
 		end
 	end


### PR DESCRIPTION
This fixes the true root cause as to why certain spawngroups (Jewelry Store/Prison Nightmare/etc) were not being used even though the vanilla code in _find_spawn_group_near_area was already properly accounting for one-way links.

Additionally though this will also resolve other cases when GroupAI searches areas with one-way links.